### PR TITLE
Allow mounting with local user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM fedora:28
 
 RUN dnf install -y texlive-scheme-full
 
+ENV HOME /home/
+RUN chmod 777 /home/
 WORKDIR /home/

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ docker build . --tag texlive
 Aliases are useful to invoke commands in the container:
 
 ```sh
-alias pdflatex="docker run -v \$(pwd):/home/ -it texlive pdflatex"
+alias pdflatex="docker run --rm -u $(id -u):$(id -g) -v "\$(pwd):/home/project" -w /home/project texlive pdflatex"
 ```


### PR DESCRIPTION
There are permission problems when trying to compile PDFs since the
HOME environment variable is used by texlive to place temporary
files. HOME is now set to the /home/ directory which allows any user
to write.

The example command in the README is updated as well to use a cleaner
docker setup.